### PR TITLE
Minor changes

### DIFF
--- a/Rock.Encryption/Async/IAsyncCrypto.cs
+++ b/Rock.Encryption/Async/IAsyncCrypto.cs
@@ -58,7 +58,7 @@ namespace RockLib.Encryption.Async
 
         /// <summary>
         /// Asynchronously gets an instance of <see cref="IAsyncEncryptor"/> for the provided
-        /// encrypt key.
+        /// key identifier.
         /// </summary>
         /// <param name="keyIdentifier">
         /// An implementation-specific object used to identify the key for this
@@ -70,8 +70,8 @@ namespace RockLib.Encryption.Async
         IAsyncEncryptor GetAsyncEncryptor(object keyIdentifier);
 
         /// <summary>
-        /// Asynchronously ets an instance of <see cref="IAsyncDecryptor"/> for the provided
-        /// encrypt key.
+        /// Asynchronously gets an instance of <see cref="IAsyncDecryptor"/> for the provided
+        /// key identifier.
         /// </summary>
         /// <param name="keyIdentifier">
         /// An implementation-specific object used to identify the key for this

--- a/Rock.Encryption/Async/SynchronousAsyncCrypto.cs
+++ b/Rock.Encryption/Async/SynchronousAsyncCrypto.cs
@@ -135,7 +135,7 @@ namespace RockLib.Encryption.Async
 
         /// <summary>
         /// Gets an instance of <see cref="SynchronousAsyncEncryptor"/> for the provided
-        /// encrypt key.
+        /// key identifier.
         /// </summary>
         /// <param name="keyIdentifier">
         /// An implementation-specific object used to identify the key for this
@@ -151,7 +151,7 @@ namespace RockLib.Encryption.Async
 
         /// <summary>
         /// Gets an instance of <see cref="SynchronousAsyncDecryptor"/> for the provided
-        /// encrypt key.
+        /// key identifier.
         /// </summary>
         /// <param name="keyIdentifier">
         /// An implementation-specific object used to identify the key for this

--- a/Rock.Encryption/CompositeCrypto.cs
+++ b/Rock.Encryption/CompositeCrypto.cs
@@ -95,7 +95,7 @@ namespace Rock.Encryption
         }
 
         /// <summary>
-        /// Gets an instance of <see cref="IEncryptor"/> for the provided encrypt key.
+        /// Gets an instance of <see cref="IEncryptor"/> for the provided key identifier.
         /// </summary>
         /// <param name="keyIdentifier">
         /// An implementation-specific object used to identify the key for this
@@ -108,7 +108,7 @@ namespace Rock.Encryption
         }
 
         /// <summary>
-        /// Gets an instance of <see cref="IDecryptor"/> for the provided encrypt key.
+        /// Gets an instance of <see cref="IDecryptor"/> for the provided key identifier.
         /// </summary>
         /// <param name="keyIdentifier">
         /// An implementation-specific object used to identify the key for this

--- a/Rock.Encryption/Crypto.cs
+++ b/Rock.Encryption/Crypto.cs
@@ -199,36 +199,18 @@ namespace Rock.Encryption
         /// <summary>
         /// Gets an instance of <see cref="IAsyncEncryptor"/> for the provided encrypt key.
         /// </summary>
-        /// <returns>An object that can be used for encryption operations.</returns>
-        public static IAsyncEncryptor GetAsyncEncryptor()
-        {
-            return GetAsyncEncryptor(null);
-        }
-
-        /// <summary>
-        /// Gets an instance of <see cref="IAsyncEncryptor"/> for the provided encrypt key.
-        /// </summary>
         /// <param name="keyIdentifier">
         /// An implementation-specific object used to identify the key for this
         /// encryption operation.
         /// </param>
         /// <returns>An object that can be used for encryption operations.</returns>
-        public static IAsyncEncryptor GetAsyncEncryptor(object keyIdentifier)
+        public static IAsyncEncryptor GetAsyncEncryptor(object keyIdentifier = null)
         {
             return Current.AsAsync().GetAsyncEncryptor(keyIdentifier);
         }
 
         /// <summary>
         /// Asynchronously gets an instance of <see cref="IAsyncDecryptor"/> for the provided
-        /// encrypt key.
-        /// </summary>
-        /// <returns>An object that can be used for decryption operations.</returns>
-        public static IAsyncDecryptor GetAsyncDecryptor()
-        {
-            return GetAsyncDecryptor(null);
-        }
-
-        /// <summary>
         /// Asynchronously gets an instance of <see cref="IAsyncDecryptor"/> for the provided
         /// encrypt key.
         /// </summary>
@@ -237,7 +219,7 @@ namespace Rock.Encryption
         /// encryption operation.
         /// </param>
         /// <returns>An object that can be used for decryption operations.</returns>
-        public static IAsyncDecryptor GetAsyncDecryptor(object keyIdentifier)
+        public static IAsyncDecryptor GetAsyncDecryptor(object keyIdentifier = null)
         {
             return Current.AsAsync().GetAsyncDecryptor(keyIdentifier);
         }

--- a/Rock.Encryption/Crypto.cs
+++ b/Rock.Encryption/Crypto.cs
@@ -46,7 +46,7 @@ namespace Rock.Encryption
         /// <param name="crypto"></param>
         /// <remarks>
         /// Each method of the <see cref="Crypto"/> class ultimately uses the value
-        /// of this property and calls one of its methods.
+        /// of the <see cref="Current"/> property and calls one of its methods.
         /// </remarks>
         public static void SetCurrent(ICrypto crypto)
         {
@@ -110,7 +110,7 @@ namespace Rock.Encryption
         }
 
         /// <summary>
-        /// Gets an instance of <see cref="IEncryptor"/> for the provided encrypt key.
+        /// Gets an instance of <see cref="IEncryptor"/> for the provided key identifier.
         /// </summary>
         /// <param name="keyIdentifier">
         /// An implementation-specific object used to identify the key for this
@@ -123,7 +123,7 @@ namespace Rock.Encryption
         }
 
         /// <summary>
-        /// Gets an instance of <see cref="IDecryptor"/> for the provided encrypt key.
+        /// Gets an instance of <see cref="IDecryptor"/> for the provided key identifier.
         /// </summary>
         /// <param name="keyIdentifier">
         /// An implementation-specific object used to identify the key for this
@@ -197,7 +197,7 @@ namespace Rock.Encryption
         }
 
         /// <summary>
-        /// Gets an instance of <see cref="IAsyncEncryptor"/> for the provided encrypt key.
+        /// Gets an instance of <see cref="IAsyncEncryptor"/> for the provided key identifier.
         /// </summary>
         /// <param name="keyIdentifier">
         /// An implementation-specific object used to identify the key for this
@@ -211,8 +211,7 @@ namespace Rock.Encryption
 
         /// <summary>
         /// Asynchronously gets an instance of <see cref="IAsyncDecryptor"/> for the provided
-        /// Asynchronously gets an instance of <see cref="IAsyncDecryptor"/> for the provided
-        /// encrypt key.
+        /// key identifier.
         /// </summary>
         /// <param name="keyIdentifier">
         /// An implementation-specific object used to identify the key for this

--- a/Rock.Encryption/ICrypto.cs
+++ b/Rock.Encryption/ICrypto.cs
@@ -54,7 +54,7 @@ namespace Rock.Encryption
         byte[] Decrypt(byte[] cipherText, object keyIdentifier);
 
         /// <summary>
-        /// Gets an instance of <see cref="IEncryptor"/> for the provided encrypt key.
+        /// Gets an instance of <see cref="IEncryptor"/> for the provided key identifier.
         /// </summary>
         /// <param name="keyIdentifier">
         /// An implementation-specific object used to identify the key for this
@@ -64,7 +64,7 @@ namespace Rock.Encryption
         IEncryptor GetEncryptor(object keyIdentifier);
 
         /// <summary>
-        /// Gets an instance of <see cref="IDecryptor"/> for the provided encrypt key.
+        /// Gets an instance of <see cref="IDecryptor"/> for the provided key identifier.
         /// </summary>
         /// <param name="keyIdentifier">
         /// An implementation-specific object used to identify the key for this

--- a/Rock.Encryption/Symmetric/SymmetricCrypto.cs
+++ b/Rock.Encryption/Symmetric/SymmetricCrypto.cs
@@ -119,7 +119,7 @@ namespace Rock.Encryption.Symmetric
         }
 
         /// <summary>
-        /// Gets an instance of <see cref="IEncryptor"/> for the provided encrypt key.
+        /// Gets an instance of <see cref="IEncryptor"/> for the provided key identifier.
         /// </summary>
         /// <param name="keyIdentifier">
         /// An implementation-specific object used to identify the key for this
@@ -138,7 +138,7 @@ namespace Rock.Encryption.Symmetric
         }
 
         /// <summary>
-        /// Gets an instance of <see cref="IDecryptor"/> for the provided encrypt key.
+        /// Gets an instance of <see cref="IDecryptor"/> for the provided key identifier.
         /// </summary>
         /// <param name="keyIdentifier">
         /// An implementation-specific object used to identify the key for this


### PR DESCRIPTION
I noticed these while prepping for publishing.

- Make api consistent
  - The other methods in the` Crypto` class have a `keyIdentifier` parameter with a null default value; `GetAsyncEncryptor` and `GetAsyncDecryptor` too.
- Improve doc comments
  - Replace "encrypt key" (which was the name of the parameter a long, long ago) with "key identifier".
  - Adjust the wording of the `SetCurrent` method.