### PR TITLE
 Add extension method overloads for ICrypto and IAsyncCrypto

### DIFF
--- a/RockLib.Encryption/Async/IAsyncCrypto.cs
+++ b/RockLib.Encryption/Async/IAsyncCrypto.cs
@@ -57,8 +57,7 @@ namespace RockLib.Encryption.Async
         Task<byte[]> DecryptAsync(byte[] cipherText, object keyIdentifier, CancellationToken cancellationToken);
 
         /// <summary>
-        /// Asynchronously gets an instance of <see cref="IAsyncEncryptor"/> for the provided
-        /// key identifier.
+        /// Gets an instance of <see cref="IAsyncEncryptor"/> for the provided key identifier.
         /// </summary>
         /// <param name="keyIdentifier">
         /// An implementation-specific object used to identify the key for this
@@ -70,8 +69,7 @@ namespace RockLib.Encryption.Async
         IAsyncEncryptor GetAsyncEncryptor(object keyIdentifier);
 
         /// <summary>
-        /// Asynchronously gets an instance of <see cref="IAsyncDecryptor"/> for the provided
-        /// key identifier.
+        /// Gets an instance of <see cref="IAsyncDecryptor"/> for the provided key identifier.
         /// </summary>
         /// <param name="keyIdentifier">
         /// An implementation-specific object used to identify the key for this

--- a/RockLib.Encryption/Async/IAsyncCryptoExtensions.cs
+++ b/RockLib.Encryption/Async/IAsyncCryptoExtensions.cs
@@ -1,0 +1,85 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace RockLib.Encryption.Async
+{
+    /// <summary>
+    /// Defines extension methods for the <see cref="IAsyncCrypto"/> interface that
+    /// make the <c>keyIdentifier</c> and <c>cancellationToken</c> parameters
+    /// optional for its methods.
+    /// </summary>
+    public static class IAsyncCryptoExtensions
+    {
+        /// <summary>
+        /// Asynchronously encrypts the specified plain text.
+        /// </summary>
+        /// <param name="crypto">An <see cref="IAsyncCrypto"/>.</param>
+        /// <param name="plainText">The plain text.</param>
+        /// <param name="keyIdentifier">
+        /// An implementation-specific object used to identify the key for this
+        /// encryption operation.
+        /// </param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>The encrypted value as a string.</returns>
+        public static Task<string> EncryptAsync(this IAsyncCrypto crypto, string plainText, object keyIdentifier = null, CancellationToken cancellationToken = default(CancellationToken)) =>
+            crypto.EncryptAsync(plainText, keyIdentifier, cancellationToken);
+
+        /// <summary>
+        /// Asynchronously decrypts the specified cipher text.
+        /// </summary>
+        /// <param name="crypto">An <see cref="IAsyncCrypto"/>.</param>
+        /// <param name="cipherText">The cipher text.</param>
+        /// <param name="keyIdentifier">
+        /// An implementation-specific object used to identify the key for this
+        /// encryption operation.
+        /// </param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>The decrypted value as a string.</returns>
+        public static Task<string> DecryptAsync(this IAsyncCrypto crypto, string cipherText, object keyIdentifier = null, CancellationToken cancellationToken = default(CancellationToken)) =>
+            crypto.DecryptAsync(cipherText, keyIdentifier, cancellationToken);
+
+        /// <summary>
+        /// Asynchronously encrypts the specified plain text.
+        /// </summary>
+        /// <param name="crypto">An <see cref="IAsyncCrypto"/>.</param>
+        /// <param name="plainText">The plain text.</param>
+        /// <param name="keyIdentifier">
+        /// An implementation-specific object used to identify the key for this
+        /// encryption operation.
+        /// </param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>The encrypted value as a byte array.</returns>
+        public static Task<byte[]> EncryptAsync(this IAsyncCrypto crypto, byte[] plainText, object keyIdentifier = null, CancellationToken cancellationToken = default(CancellationToken)) =>
+            crypto.EncryptAsync(plainText, keyIdentifier, cancellationToken);
+
+        /// <summary>
+        /// Asynchronously decrypts the specified cipher text.
+        /// </summary>
+        /// <param name="crypto">An <see cref="IAsyncCrypto"/>.</param>
+        /// <param name="cipherText">The cipher text.</param>
+        /// <param name="keyIdentifier">
+        /// An implementation-specific object used to identify the key for this
+        /// encryption operation.
+        /// </param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>The decrypted value as a byte array.</returns>
+        public static Task<byte[]> DecryptAsync(this IAsyncCrypto crypto, byte[] cipherText, object keyIdentifier = null, CancellationToken cancellationToken = default(CancellationToken)) =>
+            crypto.DecryptAsync(cipherText, keyIdentifier, cancellationToken);
+
+        /// <summary>
+        /// Gets an instance of <see cref="IAsyncEncryptor"/> using the default credential.
+        /// </summary>
+        /// <param name="crypto">An <see cref="IAsyncCrypto"/>.</param>
+        /// <returns>An object that can be used for encryption operations.</returns>
+        public static IAsyncEncryptor GetAsyncEncryptor(this IAsyncCrypto crypto) =>
+            crypto.GetAsyncEncryptor(null);
+
+        /// <summary>
+        /// Gets an instance of <see cref="IAsyncDecryptor"/> using the default credential.
+        /// </summary>
+        /// <param name="crypto">An <see cref="IAsyncCrypto"/>.</param>
+        /// <returns>An object that can be used for decryption operations.</returns>
+        public static IAsyncDecryptor GetAsyncDecryptor(this IAsyncCrypto crypto) =>
+            crypto.GetAsyncDecryptor(null);
+    }
+}

--- a/RockLib.Encryption/Crypto.cs
+++ b/RockLib.Encryption/Crypto.cs
@@ -125,7 +125,7 @@ namespace RockLib.Encryption
         }
 
         /// <summary>
-        /// Asynchronously wncrypts the specified plain text.
+        /// Asynchronously encrypts the specified plain text.
         /// </summary>
         /// <param name="plainText">The plain text.</param>
         /// <param name="keyIdentifier">
@@ -198,8 +198,7 @@ namespace RockLib.Encryption
         }
 
         /// <summary>
-        /// Asynchronously gets an instance of <see cref="IAsyncDecryptor"/> for the provided
-        /// key identifier.
+        /// Gets an instance of <see cref="IAsyncDecryptor"/> for the provided key identifier.
         /// </summary>
         /// <param name="keyIdentifier">
         /// An implementation-specific object used to identify the key for this

--- a/RockLib.Encryption/ICryptoExtensions.cs
+++ b/RockLib.Encryption/ICryptoExtensions.cs
@@ -1,0 +1,55 @@
+﻿namespace RockLib.Encryption
+{
+    /// <summary>
+    /// Defines extension methods for the <see cref="ICrypto"/> interface that allow
+    /// the user to omit the <c>keyIdentifier</c> parameter from its methods.
+    /// </summary>
+    public static class ICryptoExtensions
+    {
+        /// <summary>
+        /// Encrypts the specified plain text using the default credential.
+        /// </summary>
+        /// <param name="crypto">An <see cref="ICrypto"/>.</param>
+        /// <param name="plainText">The plain text.</param>
+        /// <returns>The encrypted value as a string.</returns>
+        public static string Encrypt(this ICrypto crypto, string plainText) => crypto.Encrypt(plainText, null);
+
+        /// <summary>
+        /// Decrypts the specified cipher text using the default credential.
+        /// </summary>
+        /// <param name="crypto">An <see cref="ICrypto"/>.</param>
+        /// <param name="cipherText">The cipher text.</param>
+        /// <returns>The decrypted value as a string.</returns>
+        public static string Decrypt(this ICrypto crypto, string cipherText) => crypto.Decrypt(cipherText, null);
+
+        /// <summary>
+        /// Encrypts the specified plain text using the default credential.
+        /// </summary>
+        /// <param name="crypto">An <see cref="ICrypto"/>.</param>
+        /// <param name="plainText">The plain text.</param>
+        /// <returns>The encrypted value as a byte array.</returns>
+        public static byte[] Encrypt(this ICrypto crypto, byte[] plainText) => crypto.Encrypt(plainText, null);
+
+        /// <summary>
+        /// Decrypts the specified cipher text using the default credential.
+        /// </summary>
+        /// <param name="crypto">An <see cref="ICrypto"/>.</param>
+        /// <param name="cipherText">The cipher text.</param>
+        /// <returns>The decrypted value as a byte array.</returns>
+        public static byte[] Decrypt(this ICrypto crypto, byte[] cipherText) => crypto.Decrypt(cipherText, null);
+
+        /// <summary>
+        /// Gets an instance of <see cref="IEncryptor"/> using the default credential.
+        /// </summary>
+        /// <param name="crypto">An <see cref="ICrypto"/>.</param>
+        /// <returns>An object that can be used for encryption operations.</returns>
+        public static IEncryptor GetEncryptor(this ICrypto crypto) => crypto.GetEncryptor(null);
+
+        /// <summary>
+        /// Gets an instance of <see cref="IDecryptor"/> using the default credential.
+        /// </summary>
+        /// <param name="crypto">An <see cref="ICrypto"/>.</param>
+        /// <returns>An object that can be used for decryption operations.</returns>
+        public static IDecryptor GetDecryptor(this ICrypto crypto) => crypto.GetDecryptor(null);
+    }
+}


### PR DESCRIPTION
These extension methods allow users to omit the `keyIdentifier` and `cancellationToken` parameters.