### PR TITLE
Update encryption package to latest prerelease for the XSerializer project

### DIFF
--- a/RockLib.Encryption.XSerializer.Tests/CryptoEncryptionMechanismTests.cs
+++ b/RockLib.Encryption.XSerializer.Tests/CryptoEncryptionMechanismTests.cs
@@ -24,16 +24,16 @@ namespace RockLib.Encryption.XSerializer.Tests
             var mockCrypto = new Mock<ICrypto>();
             var mockEncryptor = new Mock<IEncryptor>();
 
-            mockCrypto.Setup(c => c.GetEncryptor(It.IsAny<object>())).Returns(() => mockEncryptor.Object);
+            mockCrypto.Setup(c => c.GetEncryptor(It.IsAny<string>())).Returns(() => mockEncryptor.Object);
 
             var encryptionMechanism = new CryptoEncryptionMechanism(mockCrypto.Object);
 
-            var keyIdentifier = new object();
+            var credentialName = "foobar";
             var serializationState = new SerializationState();
 
-            encryptionMechanism.Encrypt("foo", keyIdentifier, serializationState);
+            encryptionMechanism.Encrypt("foo", credentialName, serializationState);
 
-            mockCrypto.Verify(c => c.GetEncryptor(It.Is<object>(obj => obj == keyIdentifier)), Times.Once());
+            mockCrypto.Verify(c => c.GetEncryptor(It.Is<string>(obj => obj == credentialName)), Times.Once());
         }
 
         [Test]
@@ -42,19 +42,19 @@ namespace RockLib.Encryption.XSerializer.Tests
             var mockCrypto = new Mock<ICrypto>();
             var mockEncryptor = new Mock<IEncryptor>();
 
-            mockCrypto.Setup(c => c.GetEncryptor(It.IsAny<object>())).Returns(() => mockEncryptor.Object);
+            mockCrypto.Setup(c => c.GetEncryptor(It.IsAny<string>())).Returns(() => mockEncryptor.Object);
 
             var encryptionMechanism = new CryptoEncryptionMechanism(mockCrypto.Object);
 
-            var keyIdentifier = new object();
+            var credentialName = "foobar";
             var serializationState = new SerializationState();
 
             // Force the mock encryptor to be cached in the serialization state.
             serializationState.Get(() => mockEncryptor.Object);
 
-            encryptionMechanism.Encrypt("foo", keyIdentifier, serializationState);
+            encryptionMechanism.Encrypt("foo", credentialName, serializationState);
 
-            mockCrypto.Verify(c => c.GetEncryptor(It.Is<object>(obj => obj == keyIdentifier)), Times.Never());
+            mockCrypto.Verify(c => c.GetEncryptor(It.Is<string>(obj => obj == credentialName)), Times.Never());
         }
 
         [Test]
@@ -63,18 +63,18 @@ namespace RockLib.Encryption.XSerializer.Tests
             var mockCrypto = new Mock<ICrypto>();
             var mockEncryptor = new Mock<IEncryptor>();
 
-            mockCrypto.Setup(c => c.GetEncryptor(It.IsAny<object>())).Returns(() => mockEncryptor.Object);
+            mockCrypto.Setup(c => c.GetEncryptor(It.IsAny<string>())).Returns(() => mockEncryptor.Object);
             mockEncryptor.Setup(e => e.Encrypt(It.IsAny<string>())).Returns("bar");
 
             var encryptionMechanism = new CryptoEncryptionMechanism(mockCrypto.Object);
 
-            var keyIdentifier = new object();
+            var credentialName = "foobar";
             var serializationState = new SerializationState();
 
             // Force the mock encryptor to be cached in the serialization state.
             serializationState.Get(() => mockEncryptor.Object);
 
-            var encrypted = encryptionMechanism.Encrypt("foo", keyIdentifier, serializationState);
+            var encrypted = encryptionMechanism.Encrypt("foo", credentialName, serializationState);
 
             encrypted.Should().Be("bar");
         }
@@ -85,16 +85,16 @@ namespace RockLib.Encryption.XSerializer.Tests
             var mockCrypto = new Mock<ICrypto>();
             var mockDecryptor = new Mock<IDecryptor>();
 
-            mockCrypto.Setup(c => c.GetDecryptor(It.IsAny<object>())).Returns(() => mockDecryptor.Object);
+            mockCrypto.Setup(c => c.GetDecryptor(It.IsAny<string>())).Returns(() => mockDecryptor.Object);
 
             var encryptionMechanism = new CryptoEncryptionMechanism(mockCrypto.Object);
 
-            var keyIdentifier = new object();
+            var credentialName = "foobar";
             var serializationState = new SerializationState();
 
-            encryptionMechanism.Decrypt("foo", keyIdentifier, serializationState);
+            encryptionMechanism.Decrypt("foo", credentialName, serializationState);
 
-            mockCrypto.Verify(c => c.GetDecryptor(It.Is<object>(obj => obj == keyIdentifier)), Times.Once());
+            mockCrypto.Verify(c => c.GetDecryptor(It.Is<string>(obj => obj == credentialName)), Times.Once());
         }
 
         [Test]
@@ -103,19 +103,19 @@ namespace RockLib.Encryption.XSerializer.Tests
             var mockCrypto = new Mock<ICrypto>();
             var mockDecryptor = new Mock<IDecryptor>();
 
-            mockCrypto.Setup(c => c.GetDecryptor(It.IsAny<object>())).Returns(() => mockDecryptor.Object);
+            mockCrypto.Setup(c => c.GetDecryptor(It.IsAny<string>())).Returns(() => mockDecryptor.Object);
 
             var encryptionMechanism = new CryptoEncryptionMechanism(mockCrypto.Object);
 
-            var keyIdentifier = new object();
+            var credentialName = "foobar";
             var serializationState = new SerializationState();
 
             // Force the mock decryptor to be cached in the serialization state.
             serializationState.Get(() => mockDecryptor.Object);
 
-            encryptionMechanism.Decrypt("foo", keyIdentifier, serializationState);
+            encryptionMechanism.Decrypt("foo", credentialName, serializationState);
 
-            mockCrypto.Verify(c => c.GetDecryptor(It.Is<object>(obj => obj == keyIdentifier)), Times.Never());
+            mockCrypto.Verify(c => c.GetDecryptor(It.Is<string>(obj => obj == credentialName)), Times.Never());
         }
 
         [Test]
@@ -124,18 +124,18 @@ namespace RockLib.Encryption.XSerializer.Tests
             var mockCrypto = new Mock<ICrypto>();
             var mockDecryptor = new Mock<IDecryptor>();
 
-            mockCrypto.Setup(c => c.GetDecryptor(It.IsAny<object>())).Returns(() => mockDecryptor.Object);
+            mockCrypto.Setup(c => c.GetDecryptor(It.IsAny<string>())).Returns(() => mockDecryptor.Object);
             mockDecryptor.Setup(e => e.Decrypt(It.IsAny<string>())).Returns("bar");
 
             var encryptionMechanism = new CryptoEncryptionMechanism(mockCrypto.Object);
 
-            var keyIdentifier = new object();
+            var credentialName = "foobar";
             var serializationState = new SerializationState();
 
             // Force the mock decryptor to be cached in the serialization state.
             serializationState.Get(() => mockDecryptor.Object);
 
-            var decrypted = encryptionMechanism.Decrypt("foo", keyIdentifier, serializationState);
+            var decrypted = encryptionMechanism.Decrypt("foo", credentialName, serializationState);
 
             decrypted.Should().Be("bar");
         }

--- a/RockLib.Encryption.XSerializer.Tests/SerializingCryptoTests.cs
+++ b/RockLib.Encryption.XSerializer.Tests/SerializingCryptoTests.cs
@@ -39,7 +39,7 @@ namespace RockLib.Encryption.XSerializer.Tests
 
             SerializingCrypto.ToXml(foo);
 
-            _mockCrypto.Verify(c => c.GetEncryptor(It.Is<object>(o => o is Type && ((Type)o) == typeof(Foo))), Times.Once());
+            _mockCrypto.Verify(c => c.GetEncryptor(It.Is<string>(o => o == null)), Times.Once());
         }
 
         [Test]
@@ -49,11 +49,11 @@ namespace RockLib.Encryption.XSerializer.Tests
 
             var foo = new Foo { Bar = _bar, Baz = _baz, Qux = _qux };
 
-            var keyIdentifier = new object();
+            var credentialName = "foobar";
 
-            SerializingCrypto.ToXml(foo, keyIdentifier);
+            SerializingCrypto.ToXml(foo, credentialName);
 
-            _mockCrypto.Verify(c => c.GetEncryptor(It.Is<object>(o => o == keyIdentifier)), Times.Once());
+            _mockCrypto.Verify(c => c.GetEncryptor(It.Is<string>(o => o == credentialName)), Times.Once());
         }
 
         [Test]
@@ -63,7 +63,7 @@ namespace RockLib.Encryption.XSerializer.Tests
 
             SerializingCrypto.FromXml<Foo>(FooXml);
 
-            _mockCrypto.Verify(c => c.GetDecryptor(It.Is<object>(o => o is Type && ((Type)o) == typeof(Foo))), Times.Once());
+            _mockCrypto.Verify(c => c.GetDecryptor(It.Is<string>(o => o == null)), Times.Once());
         }
 
         [Test]
@@ -71,11 +71,11 @@ namespace RockLib.Encryption.XSerializer.Tests
         {
             _mockCrypto.ResetCalls();
 
-            var keyIdentifier = new object();
+            var credentialName = "foobar";
 
-            SerializingCrypto.FromXml<Foo>(FooXml, keyIdentifier);
+            SerializingCrypto.FromXml<Foo>(FooXml, credentialName);
 
-            _mockCrypto.Verify(c => c.GetDecryptor(It.Is<object>(o => o == keyIdentifier)), Times.Once());
+            _mockCrypto.Verify(c => c.GetDecryptor(It.Is<string>(o => o == credentialName)), Times.Once());
         }
 
         [Test]
@@ -87,7 +87,7 @@ namespace RockLib.Encryption.XSerializer.Tests
 
             SerializingCrypto.ToJson(foo);
 
-            _mockCrypto.Verify(c => c.GetEncryptor(It.Is<object>(o => o is Type && ((Type)o) == typeof(Foo))), Times.Once());
+            _mockCrypto.Verify(c => c.GetEncryptor(It.Is<string>(o => o == null)), Times.Once());
         }
 
         [Test]
@@ -97,11 +97,11 @@ namespace RockLib.Encryption.XSerializer.Tests
 
             var foo = new Foo { Bar = _bar, Baz = _baz, Qux = _qux };
 
-            var keyIdentifier = new object();
+            var credentialName = "foobar";
 
-            SerializingCrypto.ToJson(foo, keyIdentifier);
+            SerializingCrypto.ToJson(foo, credentialName);
 
-            _mockCrypto.Verify(c => c.GetEncryptor(It.Is<object>(o => o == keyIdentifier)), Times.Once());
+            _mockCrypto.Verify(c => c.GetEncryptor(It.Is<string>(o => o == credentialName)), Times.Once());
         }
 
         [Test]
@@ -111,7 +111,7 @@ namespace RockLib.Encryption.XSerializer.Tests
 
             SerializingCrypto.FromJson<Foo>(FooJson);
 
-            _mockCrypto.Verify(c => c.GetDecryptor(It.Is<object>(o => o is Type && ((Type)o) == typeof(Foo))), Times.Once());
+            _mockCrypto.Verify(c => c.GetDecryptor(It.Is<string>(o => o == null)), Times.Once());
         }
 
         [Test]
@@ -119,11 +119,11 @@ namespace RockLib.Encryption.XSerializer.Tests
         {
             _mockCrypto.ResetCalls();
 
-            var keyIdentifier = new object();
+            var credentialName = "foobar";
 
-            SerializingCrypto.FromJson<Foo>(FooJson, keyIdentifier);
+            SerializingCrypto.FromJson<Foo>(FooJson, credentialName);
 
-            _mockCrypto.Verify(c => c.GetDecryptor(It.Is<object>(o => o == keyIdentifier)), Times.Once());
+            _mockCrypto.Verify(c => c.GetDecryptor(It.Is<string>(o => o == credentialName)), Times.Once());
         }
 
         [Test]
@@ -184,14 +184,14 @@ namespace RockLib.Encryption.XSerializer.Tests
 
         public class Base64Crypto : ICrypto
         {
-            public virtual bool CanDecrypt(object keyIdentifier) => true;
-            public virtual bool CanEncrypt(object keyIdentifier) => true;
-            public virtual string Decrypt(string cipherText, object keyIdentifier) => Base64.Decrypt(cipherText);
-            public virtual byte[] Decrypt(byte[] cipherText, object keyIdentifier) => throw new NotImplementedException();
-            public virtual string Encrypt(string plainText, object keyIdentifier) => Base64.Encrypt(plainText);
-            public virtual byte[] Encrypt(byte[] plainText, object keyIdentifier) => throw new NotImplementedException();
-            public virtual IDecryptor GetDecryptor(object keyIdentifier) => MockDecryptor.Object;
-            public virtual IEncryptor GetEncryptor(object keyIdentifier) => MockEncryptor.Object;
+            public virtual bool CanDecrypt(string credentialName) => true;
+            public virtual bool CanEncrypt(string credentialName) => true;
+            public virtual string Decrypt(string cipherText, string credentialName) => Base64.Decrypt(cipherText);
+            public virtual byte[] Decrypt(byte[] cipherText, string credentialName) => throw new NotImplementedException();
+            public virtual string Encrypt(string plainText, string credentialName) => Base64.Encrypt(plainText);
+            public virtual byte[] Encrypt(byte[] plainText, string credentialName) => throw new NotImplementedException();
+            public virtual IDecryptor GetDecryptor(string credentialName) => MockDecryptor.Object;
+            public virtual IEncryptor GetEncryptor(string credentialName) => MockEncryptor.Object;
             public Mock<Base64Encryptor> MockEncryptor { get; } = new Mock<Base64Encryptor>() { CallBase = true };
             public Mock<Base64Decryptor> MockDecryptor { get; } = new Mock<Base64Decryptor>() { CallBase = true };
         }

--- a/RockLib.Encryption.XSerializer/RockLib.Encryption.XSerializer.csproj
+++ b/RockLib.Encryption.XSerializer/RockLib.Encryption.XSerializer.csproj
@@ -28,7 +28,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="RockLib.Encryption" Version="1.0.4" />
+      <PackageReference Include="RockLib.Encryption" Version="2.0.0-alpha01" />
       <PackageReference Include="XSerializer" Version="0.4.2" />
     </ItemGroup>
 

--- a/RockLib.Encryption.XSerializer/SerializingCrypto.cs
+++ b/RockLib.Encryption.XSerializer/SerializingCrypto.cs
@@ -55,16 +55,16 @@ namespace RockLib.Encryption
         /// </summary>
         /// <typeparam name="T">The type of the instance</typeparam>
         /// <param name="instance">The instance to serialize.</param>
-        /// <param name="keyIdentifier">
-        /// An implementation-specific object used to identify the key for this
-        /// encryption operation.
+        /// <param name="credentialName">
+        /// The name of the credential to use for this encryption operation,
+        /// or null to use the default credential.
         /// </param>
         /// <returns>An XML document that represents the instance.</returns>
-        public static string ToXml<T>(T instance, object keyIdentifier)
+        public static string ToXml<T>(T instance, string credentialName)
         {
             var serializer = new XmlSerializer<T>(x => x
                 .WithEncryptionMechanism(EncryptionMechanism)
-                .WithEncryptKey(keyIdentifier ?? typeof(T)));
+                .WithEncryptKey(credentialName));
             return serializer.Serialize(instance);
         }
 
@@ -86,16 +86,16 @@ namespace RockLib.Encryption
         /// </summary>
         /// <typeparam name="T">The type to deserialize into.</typeparam>
         /// <param name="xml">The XML to deserialize.</param>
-        /// <param name="keyIdentifier">
-        /// An implementation-specific object used to identify the key for this
-        /// encryption operation.
+        /// <param name="credentialName">
+        /// The name of the credential to use for this encryption operation,
+        /// or null to use the default credential.
         /// </param>
         /// <returns>The deserialized object.</returns>
-        public static T FromXml<T>(string xml, object keyIdentifier)
+        public static T FromXml<T>(string xml, string credentialName)
         {
             var serializer = new XmlSerializer<T>(x => x
                 .WithEncryptionMechanism(EncryptionMechanism)
-                .WithEncryptKey(keyIdentifier ?? typeof(T)));
+                .WithEncryptKey(credentialName));
             return serializer.Deserialize(xml);
         }
 
@@ -117,18 +117,18 @@ namespace RockLib.Encryption
         /// </summary>
         /// <typeparam name="T">The type of the instance</typeparam>
         /// <param name="instance">The instance to serialize.</param>
-        /// <param name="keyIdentifier">
-        /// An implementation-specific object used to identify the key for this
-        /// encryption operation.
+        /// <param name="credentialName">
+        /// The name of the credential to use for this encryption operation,
+        /// or null to use the default credential.
         /// </param>
         /// <returns>A JSON document that represents the instance.</returns>
-        public static string ToJson<T>(T instance, object keyIdentifier)
+        public static string ToJson<T>(T instance, string credentialName)
         {
             var serializer =
                 new JsonSerializer<T>(new JsonSerializerConfiguration
                 {
                     EncryptionMechanism = EncryptionMechanism,
-                    EncryptKey = keyIdentifier ?? typeof(T)
+                    EncryptKey = credentialName
                 });
 
             return serializer.Serialize(instance);
@@ -152,18 +152,18 @@ namespace RockLib.Encryption
         /// </summary>
         /// <typeparam name="T">The type to deserialize into.</typeparam>
         /// <param name="json">The JSON to deserialize.</param>
-        /// <param name="keyIdentifier">
-        /// An implementation-specific object used to identify the key for this
-        /// encryption operation.
+        /// <param name="credentialName">
+        /// The name of the credential to use for this encryption operation,
+        /// or null to use the default credential.
         /// </param>
         /// <returns>The deserialized object.</returns>
-        public static T FromJson<T>(string json, object keyIdentifier)
+        public static T FromJson<T>(string json, string credentialName)
         {
             var serializer =
                 new JsonSerializer<T>(new JsonSerializerConfiguration
                 {
                     EncryptionMechanism = EncryptionMechanism,
-                    EncryptKey = keyIdentifier ?? typeof(T)
+                    EncryptKey = credentialName
                 });
 
             return serializer.Deserialize(json);

--- a/RockLib.Encryption.XSerializer/XSerializer/CryptoEncryptionMechanism.cs
+++ b/RockLib.Encryption.XSerializer/XSerializer/CryptoEncryptionMechanism.cs
@@ -34,38 +34,46 @@ namespace RockLib.Encryption.XSerializer
         /// Encrypts the specified plain text.
         /// </summary>
         /// <param name="plainText">The plain text.</param>
-        /// <param name="keyIdentifier">
-        /// An object to used to look up invokation-specific encryption parameters.
+        /// <param name="credentialName">
+        /// The name of the credential to use for this encryption operation,
+        /// or null to use the default credential.
         /// </param>
         /// <param name="serializationState">
         /// An object that holds an arbitrary value that is passed to one or more encrypt
         /// operations within a single serialization operation.
         /// </param>
         /// <returns>The encrypted text.</returns>
-        public string Encrypt(string plainText, object keyIdentifier, SerializationState serializationState)
+        public string Encrypt(string plainText, string credentialName, SerializationState serializationState)
         {
-            var encryptor = serializationState.Get(() => _crypto.GetEncryptor(keyIdentifier));
+            var encryptor = serializationState.Get(() => _crypto.GetEncryptor(credentialName?.ToString()));
             var cipherText = encryptor.Encrypt(plainText);
             return cipherText;
         }
+
+        string IEncryptionMechanism.Encrypt(string plainText, object encryptKey, SerializationState serializationState) =>
+            Encrypt(plainText, encryptKey?.ToString(), serializationState);
 
         /// <summary>
         /// Decrypts the specified cipher text.
         /// </summary>
         /// <param name="cipherText">The cipher text.</param>
-        /// <param name="keyIdentifier">
-        /// An object to used to look up invokation-specific encryption parameters.
+        /// <param name="credentialName">
+        /// The name of the credential to use for this encryption operation,
+        /// or null to use the default credential.
         /// </param>
         /// <param name="serializationState">
         /// An object that holds an arbitrary value that is passed to one or more decrypt
         /// operations within a single serialization operation.
         /// </param>
         /// <returns>The decrypted text.</returns>
-        public string Decrypt(string cipherText, object keyIdentifier, SerializationState serializationState)
+        public string Decrypt(string cipherText, string credentialName, SerializationState serializationState)
         {
-            var decryptor = serializationState.Get(() => _crypto.GetDecryptor(keyIdentifier));
+            var decryptor = serializationState.Get(() => _crypto.GetDecryptor(credentialName?.ToString()));
             var plainText = decryptor.Decrypt(cipherText);
             return plainText;
         }
+
+        string IEncryptionMechanism.Decrypt(string cipherText, object encryptKey, SerializationState serializationState) =>
+            Decrypt(cipherText, encryptKey?.ToString(), serializationState);
     }
 }


### PR DESCRIPTION
Changes the object parameter named `keyIdentifier` to be of type string and named `credentialName`.