### PR TITLE
CompositeCrypto implements IAsyncCrypto

### DIFF
--- a/RockLib.Encryption.All.sln
+++ b/RockLib.Encryption.All.sln
@@ -28,6 +28,10 @@ EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		RockLib.Encryption.XSerializer.Tests\RockLib.Encryption.XSerializer.Tests.projitems*{0ba5120d-5606-4919-bbda-4daf66b331df}*SharedItemsImports = 13
+		RockLib.Encryption.Tests\RockLib.Encryption.Tests.projitems*{31c21cc0-832c-4a4a-9841-09c16dffc5ad}*SharedItemsImports = 5
+		RockLib.Encryption.XSerializer.Tests\RockLib.Encryption.XSerializer.Tests.projitems*{33f6122f-8c89-4b65-bc10-14e8adeab79c}*SharedItemsImports = 5
+		RockLib.Encryption.Tests\RockLib.Encryption.Tests.projitems*{383f059d-1007-49f4-b090-564dc5cf3997}*SharedItemsImports = 5
+		RockLib.Encryption.XSerializer.Tests\RockLib.Encryption.XSerializer.Tests.projitems*{96546d7f-3a0a-409c-b013-61f53a1ffdad}*SharedItemsImports = 5
 		RockLib.Encryption.Tests\RockLib.Encryption.Tests.projitems*{a6e0b138-9266-41d3-8da5-570c3535e49d}*SharedItemsImports = 13
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/RockLib.Encryption.Tests/CompositeCryptoTests.cs
+++ b/RockLib.Encryption.Tests/CompositeCryptoTests.cs
@@ -216,9 +216,9 @@ namespace RockLib.Encryption.Tests
 
             var compositeCrypto = new CompositeCrypto(new List<ICrypto> { fooCrypto, barCrypto });
 
-            (await compositeCrypto.EncryptAsync("stuff", "foo")).Should().Be("EncryptAsyncedString : foo");
+            (await compositeCrypto.EncryptAsync("stuff", "foo")).Should().Be("EncryptedString : foo");
             (await compositeCrypto.EncryptAsync(new byte[0], "foo")).Should().BeEquivalentTo(Encoding.UTF8.GetBytes("foo"));
-            (await compositeCrypto.EncryptAsync("stuff", "bar")).Should().Be("EncryptAsyncedString : bar");
+            (await compositeCrypto.EncryptAsync("stuff", "bar")).Should().Be("EncryptedString : bar");
             (await compositeCrypto.EncryptAsync(new byte[0], "bar")).Should().BeEquivalentTo(Encoding.UTF8.GetBytes("bar"));
         }
 

--- a/RockLib.Encryption.Tests/CompositeCryptoTests.cs
+++ b/RockLib.Encryption.Tests/CompositeCryptoTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
@@ -48,6 +49,35 @@ namespace RockLib.Encryption.Tests
         }
 
         [Test]
+        public void GetAsyncEncryptorSucceedsWithExistingICrypto()
+        {
+            ICrypto fooCrypto = CreateICrypto("foo");
+            ICrypto barCrypto = CreateICrypto("bar");
+
+            var compositeCrypto = new CompositeCrypto(new List<ICrypto> { fooCrypto, barCrypto });
+
+            var fooEncryptor = compositeCrypto.GetAsyncEncryptor("foo");
+            var barEncryptor = compositeCrypto.GetAsyncEncryptor("bar");
+
+            fooEncryptor.Should().NotBeNull();
+            barEncryptor.Should().NotBeNull();
+            fooEncryptor.Should().NotBeSameAs(barEncryptor);
+        }
+
+        [Test]
+        public void GetAsyncEncryptorThrowsWhenICryptoDoesntExist()
+        {
+            ICrypto fooCrypto = CreateICrypto("foo");
+            ICrypto barCrypto = CreateICrypto("bar");
+
+            var compositeCrypto = new CompositeCrypto(new List<ICrypto> { fooCrypto, barCrypto });
+
+            Action action = () => compositeCrypto.GetAsyncEncryptor("baz");
+            action.Should().Throw<KeyNotFoundException>()
+                .WithMessage("Unable to locate implementation of ICrypto that can locate a credential using credentialName: baz");
+        }
+
+        [Test]
         public void GetDecryptorSucceedsWithExistingICrypto()
         {
             ICrypto fooCrypto = CreateICrypto("foo");
@@ -72,6 +102,35 @@ namespace RockLib.Encryption.Tests
             var compositeCrypto = new CompositeCrypto(new List<ICrypto> { fooCrypto, barCrypto });
 
             Action action = () => compositeCrypto.GetDecryptor("baz");
+            action.Should().Throw<KeyNotFoundException>()
+                .WithMessage("Unable to locate implementation of ICrypto that can locate a credential using credentialName: baz");
+        }
+
+        [Test]
+        public void GetAsyncDecryptorSucceedsWithExistingICrypto()
+        {
+            ICrypto fooCrypto = CreateICrypto("foo");
+            ICrypto barCrypto = CreateICrypto("bar");
+
+            var compositeCrypto = new CompositeCrypto(new List<ICrypto> { fooCrypto, barCrypto });
+
+            var fooEncryptor = compositeCrypto.GetAsyncDecryptor("foo");
+            var barEncryptor = compositeCrypto.GetAsyncDecryptor("bar");
+
+            fooEncryptor.Should().NotBeNull();
+            barEncryptor.Should().NotBeNull();
+            fooEncryptor.Should().NotBeSameAs(barEncryptor);
+        }
+
+        [Test]
+        public void GetAsyncDecryptorThrowsWhenICryptoDoesntExist()
+        {
+            ICrypto fooCrypto = CreateICrypto("foo");
+            ICrypto barCrypto = CreateICrypto("bar");
+
+            var compositeCrypto = new CompositeCrypto(new List<ICrypto> { fooCrypto, barCrypto });
+
+            Action action = () => compositeCrypto.GetAsyncDecryptor("baz");
             action.Should().Throw<KeyNotFoundException>()
                 .WithMessage("Unable to locate implementation of ICrypto that can locate a credential using credentialName: baz");
         }
@@ -150,6 +209,34 @@ namespace RockLib.Encryption.Tests
         }
 
         [Test]
+        public async Task EncryptAsyncSucceedsWithExistingICrypto()
+        {
+            ICrypto fooCrypto = CreateICrypto("foo");
+            ICrypto barCrypto = CreateICrypto("bar");
+
+            var compositeCrypto = new CompositeCrypto(new List<ICrypto> { fooCrypto, barCrypto });
+
+            (await compositeCrypto.EncryptAsync("stuff", "foo")).Should().Be("EncryptAsyncedString : foo");
+            (await compositeCrypto.EncryptAsync(new byte[0], "foo")).Should().BeEquivalentTo(Encoding.UTF8.GetBytes("foo"));
+            (await compositeCrypto.EncryptAsync("stuff", "bar")).Should().Be("EncryptAsyncedString : bar");
+            (await compositeCrypto.EncryptAsync(new byte[0], "bar")).Should().BeEquivalentTo(Encoding.UTF8.GetBytes("bar"));
+        }
+
+        [Test]
+        public async Task EncryptAsyncThrowsWhenICryptoDoesntExist()
+        {
+            ICrypto fooCrypto = CreateICrypto("foo");
+            ICrypto barCrypto = CreateICrypto("bar");
+
+            var compositeCrypto = new CompositeCrypto(new List<ICrypto> { fooCrypto, barCrypto });
+
+            Func<Task> action = () => compositeCrypto.EncryptAsync("stuff", "baz");
+
+            await action.Should().ThrowAsync<KeyNotFoundException>()
+                .WithMessage("Unable to locate implementation of ICrypto that can locate a credential using credentialName: baz");
+        }
+
+        [Test]
         public void DecryptSucceedsWithExistingICrypto()
         {
             ICrypto fooCrypto = CreateICrypto("foo");
@@ -173,6 +260,33 @@ namespace RockLib.Encryption.Tests
 
             Action action = () => compositeCrypto.Decrypt("stuff", "baz");
             action.Should().Throw<KeyNotFoundException>()
+                .WithMessage("Unable to locate implementation of ICrypto that can locate a credential using credentialName: baz");
+        }
+
+        [Test]
+        public async Task DecryptAsyncSucceedsWithExistingICrypto()
+        {
+            ICrypto fooCrypto = CreateICrypto("foo");
+            ICrypto barCrypto = CreateICrypto("bar");
+
+            var compositeCrypto = new CompositeCrypto(new List<ICrypto> { fooCrypto, barCrypto });
+
+            (await compositeCrypto.DecryptAsync("stuff", "foo")).Should().Be("DecryptedString : foo");
+            (await compositeCrypto.DecryptAsync(new byte[0], "foo")).Should().BeEquivalentTo(Encoding.UTF8.GetBytes("foo"));
+            (await compositeCrypto.DecryptAsync("stuff", "bar")).Should().Be("DecryptedString : bar");
+            (await compositeCrypto.DecryptAsync(new byte[0], "bar")).Should().BeEquivalentTo(Encoding.UTF8.GetBytes("bar"));
+        }
+
+        [Test]
+        public async Task DecryptAsyncThrowsWhenICryptoDoesntExist()
+        {
+            ICrypto fooCrypto = CreateICrypto("foo");
+            ICrypto barCrypto = CreateICrypto("bar");
+
+            var compositeCrypto = new CompositeCrypto(new List<ICrypto> { fooCrypto, barCrypto });
+
+            Func<Task> action = () => compositeCrypto.DecryptAsync("stuff", "baz");
+            await action.Should().ThrowAsync<KeyNotFoundException>()
                 .WithMessage("Unable to locate implementation of ICrypto that can locate a credential using credentialName: baz");
         }
 

--- a/RockLib.Encryption.Tests/CompositeCryptoTests.cs
+++ b/RockLib.Encryption.Tests/CompositeCryptoTests.cs
@@ -15,7 +15,7 @@ namespace RockLib.Encryption.Tests
         {
             Action action = () => new CompositeCrypto(null);
 
-            action.ShouldThrow<ArgumentNullException>().WithMessage("Value cannot be null.\r\nParameter name: cryptos");
+            action.Should().Throw<ArgumentNullException>().WithMessage("Value cannot be null.\r\nParameter name: cryptos");
         }
 
         [Test]
@@ -43,7 +43,7 @@ namespace RockLib.Encryption.Tests
             var compositeCrypto = new CompositeCrypto(new List<ICrypto> { fooCrypto, barCrypto });
 
             Action action = () => compositeCrypto.GetEncryptor("baz");
-            action.ShouldThrow<KeyNotFoundException>()
+            action.Should().Throw<KeyNotFoundException>()
                 .WithMessage("Unable to locate implementation of ICrypto that can locate a credential using credentialName: baz");
         }
 
@@ -72,7 +72,7 @@ namespace RockLib.Encryption.Tests
             var compositeCrypto = new CompositeCrypto(new List<ICrypto> { fooCrypto, barCrypto });
 
             Action action = () => compositeCrypto.GetDecryptor("baz");
-            action.ShouldThrow<KeyNotFoundException>()
+            action.Should().Throw<KeyNotFoundException>()
                 .WithMessage("Unable to locate implementation of ICrypto that can locate a credential using credentialName: baz");
         }
 
@@ -145,7 +145,7 @@ namespace RockLib.Encryption.Tests
             var compositeCrypto = new CompositeCrypto(new List<ICrypto> { fooCrypto, barCrypto });
 
             Action action = () => compositeCrypto.Encrypt("stuff", "baz");
-            action.ShouldThrow<KeyNotFoundException>()
+            action.Should().Throw<KeyNotFoundException>()
                 .WithMessage("Unable to locate implementation of ICrypto that can locate a credential using credentialName: baz");
         }
 
@@ -172,7 +172,7 @@ namespace RockLib.Encryption.Tests
             var compositeCrypto = new CompositeCrypto(new List<ICrypto> { fooCrypto, barCrypto });
 
             Action action = () => compositeCrypto.Decrypt("stuff", "baz");
-            action.ShouldThrow<KeyNotFoundException>()
+            action.Should().Throw<KeyNotFoundException>()
                 .WithMessage("Unable to locate implementation of ICrypto that can locate a credential using credentialName: baz");
         }
 

--- a/RockLib.Encryption.Tests/CredentialTests.cs
+++ b/RockLib.Encryption.Tests/CredentialTests.cs
@@ -68,7 +68,7 @@ namespace RockLib.Encryption.Tests
         public void NullKeyThrowsArgumentNullException()
         {
             Action newCredential = () => new Credential(null, SymmetricAlgorithm.Aes, 16);
-            newCredential.ShouldThrow<ArgumentNullException>();
+            newCredential.Should().Throw<ArgumentNullException>();
         }
 
         [Test]
@@ -76,7 +76,7 @@ namespace RockLib.Encryption.Tests
         {
             var credential = new Credential(() => null, SymmetricAlgorithm.Aes, 16);
             Action getKey = () => credential.GetKey();
-            getKey.ShouldThrow<InvalidOperationException>().WithMessage("The value returned from the key function must not be null or empty.");
+            getKey.Should().Throw<InvalidOperationException>().WithMessage("The value returned from the key function must not be null or empty.");
         }
 
         [Test]
@@ -84,7 +84,7 @@ namespace RockLib.Encryption.Tests
         {
             var credential = new Credential(() => new byte[0], SymmetricAlgorithm.Aes, 16);
             Action getKey = () => credential.GetKey();
-            getKey.ShouldThrow<InvalidOperationException>().WithMessage("The value returned from the key function must not be null or empty.");
+            getKey.Should().Throw<InvalidOperationException>().WithMessage("The value returned from the key function must not be null or empty.");
         }
 
         [Test]
@@ -92,7 +92,7 @@ namespace RockLib.Encryption.Tests
         {
             Action newCredential = () => new Credential(
                 () => Convert.FromBase64String("1J9Og / OaZKWdfdwM6jWMpvlr3q3o7r20xxFDN7TEj6s="), (SymmetricAlgorithm)(-1), 16);
-            newCredential.ShouldThrow<ArgumentOutOfRangeException>().WithMessage("algorithm value is not defined: -1.\r\nParameter name: algorithm");
+            newCredential.Should().Throw<ArgumentOutOfRangeException>().WithMessage("algorithm value is not defined: -1.\r\nParameter name: algorithm");
         }
 
         [Test]
@@ -101,7 +101,7 @@ namespace RockLib.Encryption.Tests
             Action newCredential = () => new Credential(
                 () => Convert.FromBase64String("1J9Og / OaZKWdfdwM6jWMpvlr3q3o7r20xxFDN7TEj6s="), SymmetricAlgorithm.Aes, 0);
 
-            newCredential.ShouldThrow<ArgumentOutOfRangeException>().WithMessage("ivSize must be greater than 0.\r\nParameter name: ivSize");
+            newCredential.Should().Throw<ArgumentOutOfRangeException>().WithMessage("ivSize must be greater than 0.\r\nParameter name: ivSize");
         }
     }
 }

--- a/RockLib.Encryption.Tests/CryptoTests.cs
+++ b/RockLib.Encryption.Tests/CryptoTests.cs
@@ -42,7 +42,7 @@ namespace RockLib.Encryption.Tests
             Crypto.SetCurrent(null);
             Action action = () => { var current = Crypto.Current; };
 
-            action.ShouldThrow<InvalidOperationException>()
+            action.Should().Throw<InvalidOperationException>()
                 .WithMessage("No crypto implementations found in config.  See the Readme.md file for details on how to setup the configuration.");
         }
 

--- a/RockLib.Encryption.Tests/SymmetricCryptoTests.cs
+++ b/RockLib.Encryption.Tests/SymmetricCryptoTests.cs
@@ -108,8 +108,8 @@ namespace RockLib.Encryption.Tests
             crypto.GetEncryptor(null).Should().NotBe(null);
             crypto.GetEncryptor("encryptor1").Should().NotBe(null);
             crypto.GetEncryptor("encryptor2").Should().NotBe(null);
-            crypto.Invoking(c => c.GetEncryptor("encryptor3")).ShouldThrow<KeyNotFoundException>().WithMessage("The specified credential was not found: encryptor3.");
-            crypto.Invoking(c => c.GetEncryptor("something")).ShouldThrow<KeyNotFoundException>().WithMessage("The specified credential was not found: something.");
+            crypto.Invoking(c => c.GetEncryptor("encryptor3")).Should().Throw<KeyNotFoundException>().WithMessage("The specified credential was not found: encryptor3.");
+            crypto.Invoking(c => c.GetEncryptor("something")).Should().Throw<KeyNotFoundException>().WithMessage("The specified credential was not found: something.");
 
             crypto.CanDecrypt(null).Should().Be(true);
             crypto.CanDecrypt("encryptor1").Should().Be(true);
@@ -120,8 +120,8 @@ namespace RockLib.Encryption.Tests
             crypto.GetDecryptor(null).Should().NotBe(null);
             crypto.GetDecryptor("encryptor1").Should().NotBe(null);
             crypto.GetDecryptor("encryptor2").Should().NotBe(null);
-            crypto.Invoking(c => c.GetDecryptor("encryptor3")).ShouldThrow<KeyNotFoundException>().WithMessage("The specified credential was not found: encryptor3.");
-            crypto.Invoking(c => c.GetDecryptor("something")).ShouldThrow<KeyNotFoundException>().WithMessage("The specified credential was not found: something.");
+            crypto.Invoking(c => c.GetDecryptor("encryptor3")).Should().Throw<KeyNotFoundException>().WithMessage("The specified credential was not found: encryptor3.");
+            crypto.Invoking(c => c.GetDecryptor("something")).Should().Throw<KeyNotFoundException>().WithMessage("The specified credential was not found: something.");
         }
 
         [Test]

--- a/RockLib.Encryption.Tests/SymmetricRoundTripTests.cs
+++ b/RockLib.Encryption.Tests/SymmetricRoundTripTests.cs
@@ -69,7 +69,7 @@ namespace RockLib.Encryption.Tests
 
             Action action = () => symmetricDecryptor.Decrypt(encrypted);
 
-            action.ShouldThrow<CryptographicException>();
+            action.Should().Throw<CryptographicException>();
         }
 
         [Test]
@@ -92,7 +92,7 @@ namespace RockLib.Encryption.Tests
 
             Action action = () => symmetricDecryptor.Decrypt(encrypted);
 
-            action.ShouldThrow<CryptographicException>();
+            action.Should().Throw<CryptographicException>();
         }
 
         [Test]

--- a/RockLib.Encryption.Tests/net451/RockLib.Encryption.Tests.net451.csproj
+++ b/RockLib.Encryption.Tests/net451/RockLib.Encryption.Tests.net451.csproj
@@ -5,11 +5,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="4.19.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="Moq" Version="4.7.99" />
-    <PackageReference Include="NUnit" Version="3.8.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Moq" Version="4.13.1" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/RockLib.Encryption.Tests/netcoreapp2.0/RockLib.Encryption.Tests.netcoreapp2.0.csproj
+++ b/RockLib.Encryption.Tests/netcoreapp2.0/RockLib.Encryption.Tests.netcoreapp2.0.csproj
@@ -5,11 +5,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="4.19.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="Moq" Version="4.7.99" />
-    <PackageReference Include="NUnit" Version="3.8.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Moq" Version="4.13.1" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/RockLib.Encryption.appveyor.yml
+++ b/RockLib.Encryption.appveyor.yml
@@ -1,5 +1,5 @@
 version: 'RockLib.Encryption.{build}.0.0-ci'
-image: Visual Studio 2017
+image: Visual Studio 2019
 configuration: Release
 only_commits:
   files:

--- a/RockLib.Encryption/CompositeCrypto.cs
+++ b/RockLib.Encryption/CompositeCrypto.cs
@@ -1,6 +1,9 @@
+using RockLib.Encryption.Async;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace RockLib.Encryption
 {
@@ -8,7 +11,7 @@ namespace RockLib.Encryption
     /// An composite implementation of <see cref="ICrypto"/> that delegates logic to an arbitrary
     /// number of other <see cref="ICrypto"/> instances.
     /// </summary>
-    public class CompositeCrypto : ICrypto
+    public class CompositeCrypto : ICrypto, IAsyncCrypto
     {
         private readonly IEnumerable<ICrypto> _cryptos;
 
@@ -49,6 +52,21 @@ namespace RockLib.Encryption
         }
 
         /// <summary>
+        /// Asynchronously encrypts the specified plain text.
+        /// </summary>
+        /// <param name="plainText">The plain text.</param>
+        /// <param name="credentialName">
+        /// The name of the credential to use for this encryption operation,
+        /// or null to use the default credential.
+        /// </param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task whose result represents the encrypted value as a string.</returns>
+        public Task<string> EncryptAsync(string plainText, string credentialName, CancellationToken cancellationToken = default)
+        {
+            return GetEncryptCrypto(credentialName).AsAsync().EncryptAsync(plainText, credentialName, cancellationToken);
+        }
+
+        /// <summary>
         /// Decrypts the specified cipher text.
         /// </summary>
         /// <param name="cipherText">The cipher text.</param>
@@ -60,6 +78,21 @@ namespace RockLib.Encryption
         public string Decrypt(string cipherText, string credentialName)
         {
             return GetDecryptCrypto(credentialName).Decrypt(cipherText, credentialName);
+        }
+
+        /// <summary>
+        /// Asynchronously decrypts the specified cipher text.
+        /// </summary>
+        /// <param name="cipherText">The cipher text.</param>
+        /// <param name="credentialName">
+        /// The name of the credential to use for this encryption operation,
+        /// or null to use the default credential.
+        /// </param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task whose result represents the decrypted value as a string.</returns>
+        public Task<string> DecryptAsync(string cipherText, string credentialName, CancellationToken cancellationToken = default)
+        {
+            return GetDecryptCrypto(credentialName).AsAsync().DecryptAsync(cipherText, credentialName, cancellationToken);
         }
 
         /// <summary>
@@ -77,6 +110,21 @@ namespace RockLib.Encryption
         }
 
         /// <summary>
+        /// Asynchronously encrypts the specified plain text.
+        /// </summary>
+        /// <param name="plainText">The plain text.</param>
+        /// <param name="credentialName">
+        /// The name of the credential to use for this encryption operation,
+        /// or null to use the default credential.
+        /// </param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task whose result represents the encrypted value as a byte array.</returns>
+        public Task<byte[]> EncryptAsync(byte[] plainText, string credentialName, CancellationToken cancellationToken = default)
+        {
+            return GetEncryptCrypto(credentialName).AsAsync().EncryptAsync(plainText, credentialName, cancellationToken);
+        }
+
+        /// <summary>
         /// Decrypts the specified cipher text.
         /// </summary>
         /// <param name="cipherText">The cipher text.</param>
@@ -88,6 +136,21 @@ namespace RockLib.Encryption
         public byte[] Decrypt(byte[] cipherText, string credentialName)
         {
             return GetDecryptCrypto(credentialName).Decrypt(cipherText, credentialName);
+        }
+
+        /// <summary>
+        /// Asynchronously decrypts the specified cipher text.
+        /// </summary>
+        /// <param name="cipherText">The cipher text.</param>
+        /// <param name="credentialName">
+        /// The name of the credential to use for this encryption operation,
+        /// or null to use the default credential.
+        /// </param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task whose result represents the decrypted value as a byte array.</returns>
+        public Task<byte[]> DecryptAsync(byte[] cipherText, string credentialName, CancellationToken cancellationToken = default)
+        {
+            return GetDecryptCrypto(credentialName).AsAsync().DecryptAsync(cipherText, credentialName, cancellationToken);
         }
 
         /// <summary>
@@ -104,6 +167,21 @@ namespace RockLib.Encryption
         }
 
         /// <summary>
+        /// Gets an instance of <see cref="IAsyncEncryptor"/> for the provided credential name.
+        /// </summary>
+        /// <param name="credentialName">
+        /// The name of the credential to use for this encryption operation,
+        /// or null to use the default credential.
+        /// </param>
+        /// <returns>
+        /// A task whose result represents an object that can be used for encryption operations.
+        /// </returns>
+        public IAsyncEncryptor GetAsyncEncryptor(string credentialName)
+        {
+            return GetEncryptCrypto(credentialName).AsAsync().GetAsyncEncryptor(credentialName);
+        }
+
+        /// <summary>
         /// Gets an instance of <see cref="IDecryptor"/> for the provided credential name.
         /// </summary>
         /// <param name="credentialName">
@@ -114,6 +192,21 @@ namespace RockLib.Encryption
         public IDecryptor GetDecryptor(string credentialName)
         {
             return GetDecryptCrypto(credentialName).GetDecryptor(credentialName);
+        }
+
+        /// <summary>
+        /// Gets an instance of <see cref="IAsyncDecryptor"/> for the provided credential name.
+        /// </summary>
+        /// <param name="credentialName">
+        /// The name of the credential to use for this encryption operation,
+        /// or null to use the default credential.
+        /// </param>
+        /// <returns>
+        /// A task whose result represents an object that can be used for decryption operations.
+        /// </returns>
+        public IAsyncDecryptor GetAsyncDecryptor(string credentialName)
+        {
+            return GetDecryptCrypto(credentialName).AsAsync().GetAsyncDecryptor(credentialName);
         }
 
         /// <summary>


### PR DESCRIPTION
Previously, when applied to a `CompositeCrypto`, the `.AsAsync()` extension method would always return a `SynchronousAsyncCrypto`, even if the `CompositeCrypto` contained cryptos that implement `IAsyncCrypto`. With the change, `CompositeCrypto` implements `IAsyncCrypto` itself and does so by calling `.AsAsync()` on whatever crypto matches an credential name.